### PR TITLE
Add the keyword `shuffle` to the function `_annotation_iterator`

### DIFF
--- a/superintendent/semisupervisor.py
+++ b/superintendent/semisupervisor.py
@@ -212,7 +212,7 @@ class SemiSupervisor():
             }
 
         self._current_annotation_iterator = self._annotation_iterator(
-            relabel, options
+            relabel, options, shuffle=shuffle
         )
         # reset the progress bar
         self.progressbar.max = relabel.sum()
@@ -221,8 +221,8 @@ class SemiSupervisor():
         # start the iteration cycle
         next(self._current_annotation_iterator)
 
-    def _annotation_iterator(self, relabel, options):
-        for i, row in self._data_iterator(self.features, shuffle=True):
+    def _annotation_iterator(self, relabel, options, shuffle=True):
+        for i, row in self._data_iterator(self.features, shuffle=shuffle):
             if relabel[i]:
                 self._render_annotator(row, options)
                 yield  # allow the user to give input


### PR DESCRIPTION
The keyword `shuffle` was missing from `_annotation_iterator`, even though it was used within this function. This issue is fixed by this pull request.