### PR TITLE
Feature: shuffle subset of points when re-ordering

### DIFF
--- a/superintendent/base.py
+++ b/superintendent/base.py
@@ -1,6 +1,7 @@
 """Base class to inherit from."""
 
 from functools import partial
+import abc
 
 import IPython.display
 import ipywidgets as widgets
@@ -10,7 +11,7 @@ import pandas as pd
 from . import display, validation, controls
 
 
-class Labeller:
+class Labeller(abc.ABC):
     """
     Data point labelling.
 
@@ -82,6 +83,14 @@ class Labeller:
 
         self.event_manager = None
         self.timer = controls.Timer()
+
+    @abc.abstractmethod
+    def annotate(self):
+        pass
+
+    @abc.abstractmethod
+    def _annotation_iterator(self):
+        pass
 
     @classmethod
     def from_dataframe(cls, features, *args, **kwargs):

--- a/superintendent/base.py
+++ b/superintendent/base.py
@@ -146,7 +146,7 @@ class Labeller:
             value = sender["value"]
         else:
             value = sender
-        self._current_annotation_iterator.send(value)
+        self._annotation_loop.send(value)
 
     def _onkeydown(self, event):
 
@@ -199,7 +199,7 @@ class Labeller:
             self._label_queue.append(curr)
             self._label_queue.append(prev)
             # send a nan for the current one - this also advances it:
-            self._current_annotation_iterator.send(np.nan)
+            self._annotation_loop.send(np.nan)
 
     def _render_processing(self, message="Rendering..."):
         self.layout.children = [

--- a/superintendent/clustersupervisor.py
+++ b/superintendent/clustersupervisor.py
@@ -72,13 +72,13 @@ class ClusterSupervisor(Labeller):
         if shuffle:
             np.random.shuffle(self._label_queue)
 
-        self._current_annotation_iterator = self._annotation_iterator()
+        self._annotation_loop = self._annotation_iterator()
         # reset the progress bar
         self.progressbar.max = len(self._label_queue)
         self.progressbar.value = 0
 
         # start the iteration cycle
-        return next(self._current_annotation_iterator)
+        return next(self._annotation_loop)
 
     def _annotation_iterator(self):
         """

--- a/superintendent/prioritisation.py
+++ b/superintendent/prioritisation.py
@@ -9,7 +9,13 @@ import scipy.stats
 import numpy as np
 
 
-def entropy(probabilities):
+def _shuffle_subset(data, shuffle_prop):
+    to_shuffle = np.nonzero(np.random.rand(data.shape[0]) < shuffle_prop)[0]
+    data[to_shuffle, ...] = data[np.random.permutation(to_shuffle), ...]
+    return data
+
+
+def entropy(probabilities, shuffle_prop=0.1):
     """
     Sort by the entropy of the probabilities (high to low).
 
@@ -18,12 +24,18 @@ def entropy(probabilities):
     probabilities : np.ndarray
         An array of probabilities, with the shape n_samples,
         n_classes
+    shuffle_prop : float
+        The proportion of data points that should be randomly shuffled. This
+        means the sorting retains some randomness, to avoid biasing your
+        new labels and catching any minority classes the algorithm currently
+        classifies as a different label.
 
     """
-    return np.argsort(-scipy.stats.entropy(probabilities.T))
+    ordered = np.argsort(-scipy.stats.entropy(probabilities.T))
+    return _shuffle_subset(ordered, shuffle_prop)
 
 
-def margin(probabilities):
+def margin(probabilities, shuffle_prop=0.1):
     """
     Sort by the margin between the top two predictions (low to high).
 
@@ -32,12 +44,18 @@ def margin(probabilities):
     probabilities : np.ndarray
         An array of probabilities, with the shape n_samples,
         n_classes
+    shuffle_prop : float
+        The proportion of data points that should be randomly shuffled. This
+        means the sorting retains some randomness, to avoid biasing your
+        new labels and catching any minority classes the algorithm currently
+        classifies as a different label.
 
     """
-    return np.argsort(
+    ordered = np.argsort(
         np.sort(probabilities, axis=1)[:, -1]
         - np.sort(probabilities, axis=1)[:, -2]
     )
+    return _shuffle_subset(ordered, shuffle_prop)
 
 
 functions = {"entropy": entropy, "margin": margin}

--- a/superintendent/semisupervisor.py
+++ b/superintendent/semisupervisor.py
@@ -47,6 +47,12 @@ class SemiSupervisor(base.Labeller):
         :py:mod:`superintendent.prioritisation`. This describes a function that
         receives input in the shape of n_samples, n_labels and calculates the
         priority in terms of information value in labelling a data point.
+    shuffle_prop : float
+        The proportion of points that are shuffled when the data points are
+        re-ordered (see reorder keyword-argument). This controls the
+        "exploration vs exploitation" trade-off - the higher, the more you
+        explore the feature space randomly, the lower, the more you exploit
+        your current weak points.
     keyboard_shortcuts : bool, optional
         If you want to enable ipyevent-mediated keyboard capture to use the
         keyboard rather than the mouse to submit data.
@@ -61,6 +67,7 @@ class SemiSupervisor(base.Labeller):
         display_func=None,
         eval_method=None,
         reorder=None,
+        shuffle_prop=0.1,
         keyboard_shortcuts=False,
         *args,
         **kwargs
@@ -83,6 +90,7 @@ class SemiSupervisor(base.Labeller):
             **kwargs
         )
         self.chunk_size = 1
+        self.shuffle_prop = shuffle_prop
         self.classifier = validation.valid_classifier(classifier)
         if self.classifier is not None:
             self.retrain_button = widgets.Button(
@@ -248,7 +256,8 @@ class SemiSupervisor(base.Labeller):
                     self.reorder(
                         self.classifier.predict_proba(
                             get_values(self.features, list(self._label_queue))
-                        )
+                        ),
+                        shuffle_prop=self.shuffle_prop
                     )
                 ]
             )

--- a/superintendent/semisupervisor.py
+++ b/superintendent/semisupervisor.py
@@ -182,14 +182,14 @@ class SemiSupervisor(base.Labeller):
         self._label_queue = deque(relabel)
         self._already_labelled = deque([])
 
-        self._current_annotation_iterator = self._annotation_iterator()
+        self._annotation_loop = self._annotation_iterator()
         # reset the progress bar
         self.progressbar.max = len(self._label_queue)
         self.progressbar.bar_style = ""
         self.progressbar.value = 0
 
         # start the iteration cycle
-        return next(self._current_annotation_iterator)
+        return next(self._annotation_loop)
 
     def _annotation_iterator(self):
         """Relabel should be integer indices"""


### PR DESCRIPTION
This allows the user to specify a proportion of points to be randomised whenever they re-train the model. This is to avoid overly biasing the created labels and goes some way towards the "exploration/exploitation" tradeoff