### PR TITLE
Add reordering to multioutput

### DIFF
--- a/superintendent/distributed/multioutput.py
+++ b/superintendent/distributed/multioutput.py
@@ -1,8 +1,8 @@
-from .. import controls
+from ..multioutput import MultiLabeller as NonDistributedMultiLabeller
 from .semisupervisor import SemiSupervisor
 
 
-class MultiLabeller(SemiSupervisor):
+class MultiLabeller(NonDistributedMultiLabeller, SemiSupervisor):
     """
     A class for labelling your data.
 
@@ -55,29 +55,4 @@ class MultiLabeller(SemiSupervisor):
 
     """
 
-    def __init__(self, *args, **kwargs):
-        """
-        A class for labelling your data.
-
-        This class is designed to label data for (semi-)supervised learning
-        algorithms. It allows you to label data, periodically re-train your
-        algorithm and assess its performance, and determine which data points
-        to label next based on your model's predictions.
-
-        """
-        super().__init__(*args, **kwargs)
-
-        if self.event_manager is not None:
-            self.event_manager.on_dom_event(
-                self.input_widget._on_key_down, remove=True
-            )
-        del self.input_widget
-        self.input_widget = controls.MulticlassSubmitter(
-            hint_function=kwargs.get("hint_function"),
-            hints=kwargs.get("hints"),
-            options=kwargs.get("options", ()),
-        )
-        self.input_widget.on_submission(self._apply_annotation)
-        if self.event_manager is not None:
-            self.event_manager.on_dom_event(self.input_widget._on_key_down)
-        self._compose()
+    pass

--- a/superintendent/multioutput/__init__.py
+++ b/superintendent/multioutput/__init__.py
@@ -1,0 +1,1 @@
+from .multilabeller import MultiLabeller  # noqa

--- a/superintendent/multioutput/multilabeller.py
+++ b/superintendent/multioutput/multilabeller.py
@@ -1,8 +1,15 @@
-from . import controls
-from .semisupervisor import SemiSupervisor
+import warnings
+from collections import OrderedDict
+
+from sklearn.preprocessing import MultiLabelBinarizer
+from sklearn.multioutput import MultiOutputClassifier
+
+from .. import controls
+from .. import semisupervisor
+from . import prioritisation
 
 
-class MultiLabeller(SemiSupervisor):
+class MultiLabeller(semisupervisor.SemiSupervisor):
     """
     A class for labelling your data.
 
@@ -65,12 +72,37 @@ class MultiLabeller(SemiSupervisor):
         to label next based on your model's predictions.
 
         """
+        reorder = kwargs.pop("reorder", None)
+
         super().__init__(*args, **kwargs)
 
         if self.event_manager is not None:
             self.event_manager.on_dom_event(
                 self.input_widget._on_key_down, remove=True
             )
+
+        if (
+            not isinstance(self.classifier, MultiOutputClassifier)
+            and self.classifier is not None
+        ):
+            self.classifier = MultiOutputClassifier(self.classifier, n_jobs=-1)
+
+        if reorder is not None and isinstance(reorder, str):
+            if reorder not in prioritisation.functions:
+                raise NotImplementedError(
+                    "Unknown reordering function '{}'.".format(reorder)
+                )
+            self.reorder = prioritisation.functions[reorder]
+        elif reorder is not None and callable(reorder):
+            self.reorder = reorder
+        elif reorder is None:
+            self.reorder = None
+        else:
+            raise ValueError(
+                "The reorder argument needs to be either a function or the "
+                "name of a function listed in superintendent.prioritisation."
+            )
+
         self.input_widget = controls.MulticlassSubmitter(
             hint_function=kwargs.get("hint_function"),
             hints=kwargs.get("hints"),
@@ -80,3 +112,63 @@ class MultiLabeller(SemiSupervisor):
         if self.event_manager is not None:
             self.event_manager.on_dom_event(self.input_widget._on_key_down)
         self._compose()
+
+    def retrain(self, *args):
+        """Retrain the classifier you passed when creating this widget.
+
+        This calls the fit method of your class with the data that you've
+        labelled. It will also score the classifier and display the
+        performance.
+        """
+        if self.classifier is None:
+            raise ValueError("No classifier to retrain.")
+
+        if len(self.queue.list_labels()) < 1:
+            self.model_performance.value = (
+                "Score: Not enough labels to retrain."
+            )
+            return
+
+        _, labelled_X, labelled_y = self.queue.list_completed()
+
+        preprocessor = MultiLabelBinarizer()
+        labelled_y = preprocessor.fit_transform(labelled_y)
+
+        self._render_processing(message="Retraining... ")
+
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                self.performance = self.eval_method(
+                    self.classifier, labelled_X, labelled_y
+                )
+                self.model_performance.value = "Score: {:.2f}".format(
+                    self.performance["test_score"].mean()
+                )
+
+        except ValueError:  # pragma: no cover
+            self.performance = "Could not evaluate"
+            self.model_performance.value = "Score: {}".format(self.performance)
+
+        self.classifier.fit(labelled_X, labelled_y)
+
+        if self.reorder is not None:
+            ids, unlabelled_X = self.queue.list_uncompleted()
+
+            probabilities = self.classifier.predict_proba(unlabelled_X)
+
+            # if len(preprocessor.classes_) > 1:
+            #     probabilities = sum(probabilities) / len(probabilities)
+
+            reordering = list(
+                self.reorder(probabilities, shuffle_prop=self.shuffle_prop)
+            )
+
+            new_order = OrderedDict(
+                [(id_, index) for id_, index in zip(ids, list(reordering))]
+            )
+
+            self.queue.reorder(new_order)
+
+        self.queue.undo()
+        self._annotation_loop.send({"source": "__skip__"})

--- a/superintendent/multioutput/prioritisation.py
+++ b/superintendent/multioutput/prioritisation.py
@@ -1,0 +1,98 @@
+"""
+Functions to prioritise labelling data points (to drive active learning).
+
+This module implements a range of functions that produce ordering of data based
+on class probabilities.
+"""
+
+from typing import List
+
+import numpy as np
+import scipy.stats
+
+from ..prioritisation import _shuffle_subset
+
+
+def entropy(
+    probabilities: List[np.ndarray], shuffle_prop: float = 0.1
+) -> np.ndarray:
+    """
+    Sort by the entropy of the probabilities (high to low).
+
+    Parameters
+    ----------
+    probabilities : np.ndarray
+        An array of probabilities, with the shape n_samples,
+        n_classes
+    shuffle_prop : float
+        The proportion of data points that should be randomly shuffled. This
+        means the sorting retains some randomness, to avoid biasing your
+        new labels and catching any minority classes the algorithm currently
+        classifies as a different label.
+
+    """
+    entropies = sum(
+        [
+            -scipy.stats.entropy(probability_array.T)
+            for probability_array in probabilities
+        ]
+    ) / len(probabilities)
+    ordered = np.argsort(entropies)
+    return _shuffle_subset(ordered.argsort(), shuffle_prop)
+
+
+def margin(probabilities: List[np.ndarray], shuffle_prop=0.1):
+    """
+    Sort by the margin between the top two predictions (low to high).
+
+    Parameters
+    ----------
+    probabilities : np.ndarray
+        An array of probabilities, with the shape n_samples,
+        n_classes
+    shuffle_prop : float
+        The proportion of data points that should be randomly shuffled. This
+        means the sorting retains some randomness, to avoid biasing your
+        new labels and catching any minority classes the algorithm currently
+        classifies as a different label.
+
+    """
+    margins = sum(
+        [
+            np.sort(probability_array, axis=1)[:, -1]
+            - np.sort(probability_array, axis=1)[:, -2]
+            for probability_array in probabilities
+        ]
+    ) / len(probabilities)
+    ordered = np.argsort(margins)
+    return _shuffle_subset(ordered.argsort(), shuffle_prop)
+
+
+def certainty(probabilities, shuffle_prop=0.1):
+    """
+    Sort by the certainty of the maximum prediction.
+
+    Parameters
+    ----------
+    probabilities : np.ndarray
+        An array of probabilities, with the shape n_samples,
+        n_classes
+    shuffle_prop : float
+        The proportion of data points that should be randomly shuffled. This
+        means the sorting retains some randomness, to avoid biasing your
+        new labels and catching any minority classes the algorithm currently
+        classifies as a different label.
+
+    """
+    certainties = sum(
+        [
+            np.max(probability_array, axis=1)
+            for probability_array in probabilities
+        ]
+    ) / len(probabilities)
+    ordered = np.argsort(certainties)
+    return _shuffle_subset(ordered.argsort(), shuffle_prop)
+
+
+functions = {"entropy": entropy, "margin": margin, "certainty": certainty}
+"""A dictionary of functions to prioritise data."""

--- a/tests/test_multioutput_prioritisation.py
+++ b/tests/test_multioutput_prioritisation.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from superintendent.multioutput.prioritisation import (
+    _shuffle_subset,
+    margin,
+    entropy,
+    certainty,
+)
+
+
+def test_no_shuffling():
+    test_data = np.random.rand(100, 10)
+    for _ in range(10):
+        assert (test_data == _shuffle_subset(test_data, 0)).all()
+
+
+def test_shuffling_all():
+    test_data = np.random.rand(100, 10)
+    assert not (test_data == _shuffle_subset(test_data.copy(), 1.0)).all()
+
+
+def test_margin():
+    probabilites = [
+        np.array([[0.19, 0.29, 0.1], [0.005, 0.8, 0.09], [0.49, 0.52, 0.0]]),
+        np.array([[0.21, 0.31, 0.1], [0.015, 1.0, 0.09], [0.51, 0.48, 0.0]]),
+    ]
+    assert (margin(probabilites, shuffle_prop=0) == np.array([1, 2, 0])).all()
+
+
+def test_entropy():
+    probabilites = [
+        np.array([[0.19, 0.29, 0.1], [0.005, 0.8, 0.09], [0.49, 0.52, 0.0]]),
+        np.array([[0.21, 0.31, 0.1], [0.015, 1.0, 0.09], [0.51, 0.48, 0.0]]),
+    ]
+    assert (entropy(probabilites, shuffle_prop=0) == np.array([0, 2, 1])).all()
+
+
+def test_certainty():
+    probabilites = [
+        np.array([[0.19, 0.29, 0.1], [0.005, 0.8, 0.09], [0.49, 0.52, 0.0]]),
+        np.array([[0.21, 0.31, 0.1], [0.015, 1.0, 0.09], [0.51, 0.48, 0.0]]),
+    ]
+    assert (
+        certainty(probabilites, shuffle_prop=0) == np.array([0, 2, 1])
+    ).all()


### PR DESCRIPTION
This implements a `retrain` method for the multioutput labelling widget.

It uses sklearn's `MultiOutputClassifier` to do the classification, and it takes the average of prioritisation metrics to do the prioritisation (e.g. average entropy, average margin, etc)

@cahlheim could you take a look?