### PR TITLE
Bugfix: layout change

### DIFF
--- a/src/superintendent/__init__.py
+++ b/src/superintendent/__init__.py
@@ -4,4 +4,4 @@ from .multiclass_labeller import MultiClassLabeller
 from .base import Labeller
 
 __all__ = ["MultiClassLabeller", "ClassLabeller", "Labeller"]
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/src/superintendent/base.py
+++ b/src/superintendent/base.py
@@ -305,7 +305,7 @@ class Labeller(widgets.VBox):
                 width="100%",
             ),
         )
-        self.layout.children = [self.progressbar, finish_celebration]
+        self.children = [self.progressbar, finish_celebration]
 
     @property
     def new_labels(self):


### PR DESCRIPTION
Fixes a bug with the display of the "finish" message. This was not being set as the correct attribute - it was being assigned to `widget.layout.children`; where `widget.layout` used to be an instance of `ipywidgets.VBox` - whereas now, `superintendent.Labeller` inherits from `VBox`

This fixes #54 